### PR TITLE
Fixed faulty /home positioning

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/util/Utils.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/util/Utils.java
@@ -126,6 +126,7 @@ public class Utils {
         AIR_MATERIALS.add(Material.WOOD_PLATE.getId());
         AIR_MATERIALS.add(Material.IRON_DOOR_BLOCK.getId());
         AIR_MATERIALS.add(Material.WOODEN_DOOR.getId());
+        AIR_MATERIALS.add(Material.SNOW.getId());
     }
 
     public static Location getSafeDestination(final Location loc) throws Exception {
@@ -133,9 +134,9 @@ public class Utils {
             throw new Exception("Invalid Location Object");
         }
         final World world = loc.getWorld();
-        int x = (int) Math.round(loc.getX());
-        int y = (int) Math.round(loc.getY());
-        int z = (int) Math.round(loc.getZ());
+        int x = (int) Math.floor(loc.getX());
+        int y = (int) Math.ceil(loc.getY());
+        int z = (int) Math.floor(loc.getZ());
 
         while (isBlockAboveAir(world, x, y, z)) {
             y -= 1;


### PR DESCRIPTION
When setting your home at coodinates like "100.7 20.0 100.7" where the x/z decimals are > .5, /home rounded up and teleported you to the neighbouring block. This was caused by `Math.round` which I now replaced. 
For the y it was wrong too, but it didn't make a difference since the only block with < .5 decimal when standing on it is a trapdoor, and you listed that as AIR. I fixed it anyway tho. (Has to be `ceil` and not `floor` here because else it would try to put you inside the block, if you're standing on a slab for example.)

I also added `SNOW` layer to the `AIR_MATERIALS` as you can literally just walk through it, they don't have a hitbox in beta. So now when setting your home on a snow layer, it won't spawn you in one block above, but just ontop of the block the snow layer is on.

Tested it all, in positive and negative coordinates, on slabs, flat surface, etc.