### PR TITLE
Fix removal of all instances of X item from inv if amount == 1

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHat.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHat.java
@@ -48,7 +48,7 @@ public class CommandHat implements CommandExecutor {
                 if (item.getAmount() > 1) {
                     item.setAmount(item.getAmount() - 1);
                 } else {
-                    this.removeExact(inventory, item);
+                    this.removeExact(inv, item);
                 }
 
                 if (helmet.getAmount() > 0) {
@@ -76,14 +76,14 @@ public class CommandHat implements CommandExecutor {
         return material == null ? null : new ItemStack(material, count);
     }
 
-    private void removeExact(PlayerInventory inventory, ItemStack item) {
-        ItemStack[] contents = inventory.getContents();
+    private void removeExact(PlayerInventory inv, ItemStack item) {
+        ItemStack[] contents = inv.getContents();
         for (int i = 0; i < contents.length; i++) {
             if (contents[i] != null && contents[i].equals(item)) {
                 if (contents[i].getAmount() > 1) {
                     contents[i].setAmount(contents[i].getAmount() - 1);
                 } else {
-                    inventory.setItem(i, null);
+                    inv.setItem(i, null);
                 }
                 break;
             }

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHat.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHat.java
@@ -48,7 +48,7 @@ public class CommandHat implements CommandExecutor {
                 if (item.getAmount() > 1) {
                     item.setAmount(item.getAmount() - 1);
                 } else {
-                    inv.remove(item);
+                    this.removeExact(inventory, item);
                 }
 
                 if (helmet.getAmount() > 0) {
@@ -74,5 +74,19 @@ public class CommandHat implements CommandExecutor {
     public ItemStack stackFromString(String item, int count) {
         Material material = Material.matchMaterial(item);
         return material == null ? null : new ItemStack(material, count);
+    }
+
+    private void removeExact(PlayerInventory inventory, ItemStack item) {
+        ItemStack[] contents = inventory.getContents();
+        for (int i = 0; i < contents.length; i++) {
+            if (contents[i] != null && contents[i].equals(item)) {
+                if (contents[i].getAmount() > 1) {
+                    contents[i].setAmount(contents[i].getAmount() - 1);
+                } else {
+                    inventory.setItem(i, null);
+                }
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
If a player has multiple instances of the same item with an amount of exactly 1 within their inventory, `/hat` will remove all of those instances from the inventory upon setting that block as the hat.