### PR TITLE
Save data asynchronously

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/Fundamentals.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/Fundamentals.java
@@ -164,18 +164,16 @@ public class Fundamentals extends JavaPlugin {
         Bukkit.getPluginCommand("balancetop").setExecutor(new CommandBalanceTop(plugin));
         Bukkit.getPluginCommand("fakequit").setExecutor(new CommandFakeQuit(plugin));
         //Timer
-        //This async task is so TPS doesn't affect the timing of saving. This probably actually isn't needed TBH.
+        //This async task is here to prevent lags from occuring when data is being saved,
+        //and to ensure TPS doesn't affect the timing of saving.
         Bukkit.getScheduler().scheduleAsyncRepeatingTask(plugin, () -> {
-            //Change back to main thread for all logic.
-            Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
-                int autoSavePeriod = FundamentalsConfig.getInstance(plugin).getConfigInteger("settings.auto-save-time");
-                if (lastAutoSaveTime + autoSavePeriod < getUnix()) {
-                    lastAutoSaveTime = getUnix();
-                    debugLogger(Level.INFO, "Automatically saving data.", 2);
-                    saveData();
-                }
-                FundamentalsPlayerMap.getInstance(plugin).runTimerTasks();
-            });
+            int autoSavePeriod = getFundamentalConfig().getConfigInteger("settings.auto-save-time");
+            if (lastAutoSaveTime + autoSavePeriod < getUnix()) {
+                lastAutoSaveTime = getUnix();
+                debugLogger(Level.INFO, "Automatically saving data.", 2);
+                saveData();
+            }
+            getPlayerMap().runTimerTasks();
         }, 20, 20 * 10);
 
         long endTimeUnix = System.currentTimeMillis() / 1000L;
@@ -296,7 +294,7 @@ public class Fundamentals extends JavaPlugin {
     }
 
     public void saveData() {
-        FundamentalsPlayerMap.getInstance().saveData();
+        getPlayerMap().saveData();
         economyCache.saveData();
 //        uuidCache.saveData();
         playerCache.saveData();

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/FundamentalsPlayerMap.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/FundamentalsPlayerMap.java
@@ -7,15 +7,15 @@ import org.bukkit.event.player.PlayerEvent;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 
 public class FundamentalsPlayerMap {
     private static FundamentalsPlayerMap singleton;
     private Fundamentals plugin;
-    private HashMap<UUID, FundamentalsPlayer> playerMap = new HashMap<UUID, FundamentalsPlayer>();
+    private ConcurrentHashMap<UUID, FundamentalsPlayer> playerMap = new ConcurrentHashMap<>();
     private ArrayList<UUID> knownPlayers = new ArrayList<UUID>();
     private boolean cacheAllPlayers = false;
     private int playersLoaded = 0;
@@ -98,7 +98,7 @@ public class FundamentalsPlayerMap {
 
 
     public void runTimerTasks() {
-        Long currentUnix = System.currentTimeMillis() / 1000L;
+        long currentUnix = System.currentTimeMillis() / 1000L;
         playerMap.keySet().removeIf(key -> {
             FundamentalsPlayer player = playerMap.get(key);
             if (!player.isPlayerOnline()) {


### PR DESCRIPTION
The current implementation schedules tasks asynchronously to save data, but the data itself isn't actually being saved asynchronously which can cause lags with bigger amounts of data.