### PR TITLE
Readd multiworld weather command from reverted "Add extended chat/command functionality" PR

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/Fundamentals.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/Fundamentals.java
@@ -160,6 +160,7 @@ public class Fundamentals extends JavaPlugin {
 //        Bukkit.getPluginCommand("time").setExecutor(new CommandTime(plugin));
 //        Bukkit.getPluginCommand("ptime").setExecutor(new CommandPTime(plugin));
         Bukkit.getPluginCommand("vanish").setExecutor(new CommandVanish(plugin));
+        Bukkit.getPluginCommand("weather").setExecutor(new CommandWeather());
         Bukkit.getPluginCommand("bank").setExecutor(new CommandBank(plugin));
         Bukkit.getPluginCommand("balancetop").setExecutor(new CommandBalanceTop(plugin));
         Bukkit.getPluginCommand("fakequit").setExecutor(new CommandFakeQuit(plugin));

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandWeather.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandWeather.java
@@ -1,0 +1,71 @@
+package com.johnymuffin.beta.fundamentals.commands;
+import com.johnymuffin.beta.fundamentals.settings.FundamentalsLanguage;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import java.util.ArrayList;
+import java.util.List;
+public class CommandWeather implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender commandSender, Command command, String s, String[] strings) {
+        Player player;
+        List<World> worlds = new ArrayList<>();
+        String worldarg;
+        if (!(commandSender.hasPermission("fundamentals.weather") || commandSender.isOp())) {
+            commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("no_permission"));
+            return true;
+        }
+        if (strings.length < 1) {
+            commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("weather_invalid_usage"));
+            return true;
+        }
+        if (strings.length < 2) {
+            player = (Player) commandSender;
+            worlds.add(0, player.getWorld());
+        }
+        else {
+            worldarg = strings[1];
+            if (worldarg.equals("all")) {
+                worlds = Bukkit.getWorlds();
+            }
+            else {
+                worlds.add(0, Bukkit.getWorld(worldarg));
+            }
+        }
+        String arg = strings[0].toLowerCase();
+        for (World world : worlds) {
+            switch (arg) {
+                case "clear":
+                case "sun":
+                    if (world.hasStorm()) {
+                        world.setThundering(false);
+                        world.setWeatherDuration(5);
+                    }
+                    break;
+                case "storm":
+                    if (!world.hasStorm()) {
+                        world.setWeatherDuration(5);
+                    }
+                    world.setThundering(true);
+                    break;
+                case "rain":
+                    if (!world.hasStorm()) {
+                        world.setWeatherDuration(5);
+                    }
+                    world.setThundering(false);
+                    break;
+                default:
+                    commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("weather_invalid_usage"));
+                    return true;
+            }
+            commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("weather_set_weather")
+                    .replace("%var1%", arg)
+                    .replace("%var2%", world.getName())
+            );
+        }
+        return true;
+    }
+}

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
@@ -108,6 +108,9 @@ public class FundamentalsLanguage extends Configuration {
         map.put("vanish_successful_other_disabled", "&4Disabled vanish for another player.");
         map.put("vanish_disable", "&4Vanish Disabled.");
         map.put("vanish_enable", "&7Vanish Enabled.");
+        //Weather
+        map.put("weather_invalid_usage", "&6Invalid usage: &a/weather <clear|sun|rain|storm> [worldname|all]");
+        map.put("weather_set_weather", "&7Weather has been set to %var1% in %var2%");
         //Clear Inventory
         map.put("clearinventory_notice", "&9Your inventory has been cleared");
         map.put("clearinventory_successfully", "&9Inventory cleared successfully");

--- a/FundamentalsCore/src/main/resources/plugin.yml
+++ b/FundamentalsCore/src/main/resources/plugin.yml
@@ -67,6 +67,9 @@ commands:
   vanish:
     description: Command to vanish player.
     usage: /<command>
+  weather:
+    description: Command to change the weather in a world.
+    usage: /<command> <clear|sun|rain|storm> [worldname|all]
   bank:
     description: Command to do bank stuff.
     usage: /<command>


### PR DESCRIPTION
I made this command as part of that PR and it isn't part of the problem which caused the reversal. The command has multiworld support and support for setting rain and storm separately instead of just storm in its Essentials counterpart.