### PR TITLE
Update build-and-test.yaml to use upload-artifact v4

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -35,7 +35,7 @@ jobs:
           mvn clean install
 
       - name: Upload JAR files from all modules
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ github.event.repository.name }}-${{ github.sha }}
           path: |


### PR DESCRIPTION
As of January 30th, 2025, GitHub actions will no longer be able to use v3 of upload-artifact. If this update is not made, our build-and-test action will fail.