### PR TITLE
Fixed listening for essentials /nick

### DIFF
--- a/FundamentalsImport/src/main/java/com/johnymuffin/fundamentals/importer/FSBPlayerListener.java
+++ b/FundamentalsImport/src/main/java/com/johnymuffin/fundamentals/importer/FSBPlayerListener.java
@@ -1,14 +1,19 @@
 package com.johnymuffin.fundamentals.importer;
 
+import com.earth2me.essentials.Essentials;
+import com.earth2me.essentials.User;
 import com.johnymuffin.beta.fundamentals.player.FundamentalsPlayer;
 import com.johnymuffin.discordcore.DiscordCore;
 import com.johnymuffin.fundamentals.importer.essentials.EssentialsManager;
 import com.johnymuffin.fundamentals.importer.tasks.LWCTransfer;
 import com.johnymuffin.fundamentals.importer.tasks.TownyTransfer;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.util.ArrayList;
@@ -23,6 +28,25 @@ public class FSBPlayerListener implements Listener {
         this.essM = new EssentialsManager(plugin.getFundamentals());
     }
 
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        String command = event.getMessage();
+        Player player = event.getPlayer();
+
+        if (command.toLowerCase().startsWith("/nick") || command.toLowerCase().startsWith("/nickname")) {
+            // why would anyone run a delayed task in a preprocess event? if it can be used elsewhere it can be used here is what i say
+            Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+                //stupid essentials nickname shenanigans
+
+                if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+                    Essentials essentials = plugin.getEssentials();
+                    User user = essentials.getUser(player);
+                    String nickname = user.getNick();
+                    player.setDisplayName(nickname);
+                }
+            }, 10L);
+        }
+    }
     @EventHandler(ignoreCancelled = true, priority = Event.Priority.Monitor)
     public void onPlayerJoin(PlayerJoinEvent event) {
         if (!event.getPlayer().isOnline()) {

--- a/FundamentalsImport/src/main/java/com/johnymuffin/fundamentals/importer/FSBPlayerListener.java
+++ b/FundamentalsImport/src/main/java/com/johnymuffin/fundamentals/importer/FSBPlayerListener.java
@@ -2,6 +2,7 @@ package com.johnymuffin.fundamentals.importer;
 
 import com.earth2me.essentials.Essentials;
 import com.earth2me.essentials.User;
+import com.johnymuffin.beta.fundamentals.FundamentalsPlayerMap;
 import com.johnymuffin.beta.fundamentals.player.FundamentalsPlayer;
 import com.johnymuffin.discordcore.DiscordCore;
 import com.johnymuffin.fundamentals.importer.essentials.EssentialsManager;
@@ -32,6 +33,7 @@ public class FSBPlayerListener implements Listener {
     public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
         String command = event.getMessage();
         Player player = event.getPlayer();
+        FundamentalsPlayer fPlayer = FundamentalsPlayerMap.getInstance().getPlayer(player);
 
         if (command.toLowerCase().startsWith("/nick") || command.toLowerCase().startsWith("/nickname")) {
             // why would anyone run a delayed task in a preprocess event? if it can be used elsewhere it can be used here is what i say
@@ -43,6 +45,7 @@ public class FSBPlayerListener implements Listener {
                     User user = essentials.getUser(player);
                     String nickname = user.getNick();
                     player.setDisplayName(nickname);
+                    fPlayer.updateDisplayName();
                 }
             }, 10L);
         }


### PR DESCRIPTION
Spent a while trying to figure out WHERE the nickname information comes from. Looks like getNick() command on essentials users is what builds the full nickname using the rank prefix and ~. Used the PlayerCommandPreprocessEvent to look for /nick calls (similar to in FundamentalsPlayerListener.java) and wrote some logic to check for essentials, and, if exists, apply the username on nick call. 

It is rather STOOPID to use a delayed task on a preprocess event but it works ig. Don't yell at me I just got it from FundamentalsPlayerListener class.