### PR TITLE
bank name limit and bug fix

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandBank.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandBank.java
@@ -1,12 +1,17 @@
 package com.johnymuffin.beta.fundamentals.commands;
 
-import com.johnymuffin.beta.fundamentals.Fundamentals;
-import com.johnymuffin.beta.fundamentals.api.EconomyAPI;
-import com.johnymuffin.beta.fundamentals.api.FundamentalsAPI;
-import com.johnymuffin.beta.fundamentals.banks.FundamentalsBank;
-import com.johnymuffin.beta.fundamentals.events.BankCreationEvent;
-import com.johnymuffin.beta.fundamentals.settings.BankManager;
-import com.johnymuffin.beta.fundamentals.settings.FundamentalsLanguage;
+import static com.johnymuffin.beta.fundamentals.FundamentalPermission.isPlayerAuthorized;
+import static com.johnymuffin.beta.fundamentals.util.Utils.getPlayerName;
+import static com.johnymuffin.beta.fundamentals.util.Utils.getUUIDFromUsername;
+import static com.johnymuffin.beta.fundamentals.util.Utils.isInt;
+import static com.johnymuffin.beta.fundamentals.util.Utils.sendLangFileMessage;
+import static com.johnymuffin.beta.fundamentals.util.Utils.sendNewLinedMessage;
+
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
@@ -14,12 +19,13 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.HashMap;
-import java.util.UUID;
-import java.util.logging.Level;
-
-import static com.johnymuffin.beta.fundamentals.FundamentalPermission.isPlayerAuthorized;
-import static com.johnymuffin.beta.fundamentals.util.Utils.*;
+import com.johnymuffin.beta.fundamentals.Fundamentals;
+import com.johnymuffin.beta.fundamentals.api.EconomyAPI;
+import com.johnymuffin.beta.fundamentals.api.FundamentalsAPI;
+import com.johnymuffin.beta.fundamentals.banks.FundamentalsBank;
+import com.johnymuffin.beta.fundamentals.events.BankCreationEvent;
+import com.johnymuffin.beta.fundamentals.settings.BankManager;
+import com.johnymuffin.beta.fundamentals.settings.FundamentalsLanguage;
 
 public class CommandBank implements CommandExecutor {
 
@@ -67,9 +73,8 @@ public class CommandBank implements CommandExecutor {
                 }
                 //Actually trying to make an account
                 String name = strings[1];
-                //TODO: Banks should probably have its own function
-                if (!verifyHomeName(name)) {
-                    commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("bank_invalid_nam"));
+                if (!verifyBankName(name)) {
+                    commandSender.sendMessage(FundamentalsLanguage.getInstance().getMessage("bank_invalid_name"));
                     return true;
                 }
                 //Verify name isn't already in use
@@ -358,5 +363,10 @@ public class CommandBank implements CommandExecutor {
         return username;
     }
 
-
+    public static boolean verifyBankName(String name) {
+        return(
+            Pattern.matches("^[a-zA-Z0-9]+$", name) &&
+            name.length() <= 16
+        );
+    }
 }

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
@@ -143,7 +143,7 @@ public class FundamentalsLanguage extends Configuration {
         map.put("bank_delete", "&4You haven't provided enough arguments, /bank delete (name)");
         map.put("bank_edit_access", "&4You haven't provided enough arguments, /bank (name) (add/remove) (username/uuid)");
         map.put("bank_withdraw", "&4You haven't provided enough arguments, /bank (name) (deposit/withdraw) (amount)");
-        map.put("bank_invalid_name", "&4Only alphanumeric characters can be used in a bank name, A-Z,0-9");
+        map.put("bank_invalid_name", "&4Bank names must be no more than 16 characters, and use any of {A-Z,a-z,0-9}");
         map.put("bank_already_exists", "&4A bank with that name already exists. Please try another name.");
         map.put("bank_created_successfully", "&6Your bank account has been created successfully.");
         map.put("bank_deleted_successfully", "&4Your bank account has been deleted successfully.");


### PR DESCRIPTION
bank names are now restricted to 16 characters or less
the feedback message no longer prints bank_invalid_nam, and instead prints actual feedback