### PR TITLE
Backport the old Commandhome usage

### DIFF
--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHome.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/commands/CommandHome.java
@@ -44,6 +44,11 @@ public class CommandHome implements CommandExecutor {
         switch(args.length) {
             case 1: {
                 String homeName = args[0];
+                if(canSeeOtherPlayerHomes && homeName.contains(":")) {
+                    oldHomesBackport(senderPlayer, homeName);
+                    return true;
+                }
+
                 teleportToSendersHome(senderPlayer, homeName);
 
                 return true;
@@ -55,22 +60,33 @@ public class CommandHome implements CommandExecutor {
                 }
 
                 String otherPlayer = args[0];
-                if(otherPlayer.isEmpty()) {
-                    String message = getMessage("home_empty_player_target");
-                    sender.sendMessage(message);
-                    
-                    return true;
-                }
-                
                 String homeName = args[1];
-                teleportToOtherPlayerHome(senderPlayer, homeName, otherPlayer);
-                
+                handleOtherPlayerHomeUse(senderPlayer, homeName, otherPlayer);
+
                 return true;
             }
         }
 
         printUsage(senderPlayer, canSeeOtherPlayerHomes);
         return true;
+    }
+
+    private void handleOtherPlayerHomeUse(Player sender, String homeName, String otherPlayer) {
+        if(otherPlayer.isEmpty()) {
+            String message = getMessage("home_empty_player_target");
+            sender.sendMessage(message);
+
+            return;
+        }
+
+        if(homeName.isEmpty()) {
+            CommandHomes commandHomes = new CommandHomes();
+            commandHomes.onCommand(sender, null, "homes", new String[] {otherPlayer});
+
+            return;
+        }
+
+        teleportToOtherPlayerHome(sender, homeName, otherPlayer);
     }
 
     private boolean canUseCommand(CommandSender sender) {
@@ -103,8 +119,26 @@ public class CommandHome implements CommandExecutor {
 
     private void printUsage(Player sender, boolean canSeeOtherPlayersHomes) {
         sender.sendMessage(getMessage("home_usage"));
-        if(canSeeOtherPlayersHomes)
-            sender.sendMessage(getMessage("home_usage_staff_extra"));
+        
+        if(!canSeeOtherPlayersHomes)
+            return;
+
+        sender.sendMessage(getMessage("home_usage_staff_extra"));
+        sender.sendMessage(getMessage("home_usage_staff_extra_backport"));
+    }
+
+    private void oldHomesBackport(Player sender, String input) {
+        String[] args = input.split(":");
+
+        if(args.length == 0) {
+            printUsage(sender, true);
+            return;
+        } 
+
+        String otherPlayer = args[0];
+        String homeName = (args.length > 1)? args[1] : "";
+        
+        handleOtherPlayerHomeUse(sender, homeName, otherPlayer);
     }
 
     private void teleportToSendersHome(Player sender, String homeName) {

--- a/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
+++ b/FundamentalsCore/src/main/java/com/johnymuffin/beta/fundamentals/settings/FundamentalsLanguage.java
@@ -51,6 +51,7 @@ public class FundamentalsLanguage extends Configuration {
         map.put("home_teleport_successfully_others", "&7Teleported to &b%targetPlayerName%&7's home &b%homeName%&7.");
         map.put("home_usage", "&7Usage: &b/home <home_name>");
         map.put("home_usage_staff_extra", "&b/home <player> <home_name>");
+        map.put("home_usage_staff_extra_backport", "&b/home <player>:[home_name]");
         //Homes
         map.put("homes_non_recorded", "&7No homes on record. Please set one with &b/sethome&7.");
         map.put("homes_non_recorded_others", "&b%targetPlayerName%&7 has no homes on record.");


### PR DESCRIPTION
This reintroduces the `/home <player>:[home_name]` syntax